### PR TITLE
Remove background color from dark mode images

### DIFF
--- a/src/sphinx_image_inverter/static/image_dark_mode_alt.css
+++ b/src/sphinx_image_inverter/static/image_dark_mode_alt.css
@@ -7,7 +7,6 @@ html[data-theme="dark"] iframe:not([src*="youtube.com"]):not([src*="vimeo.com"])
 html[data-theme="dark"] img:not(.sd-tab-set.docutils img):not(.only-dark):not(.logo__image),
 html[data-theme="dark"] figure:not(.sd-tab-set.docutils figure) img:not(.only-dark),
 html[data-theme="dark"] iframe:not([src*="youtube.com"]):not([src*="vimeo.com"]):not(.only-dark):not(.sphinx) {
-  background-color: #fff !important;
   mix-blend-mode: plus-lighter !important;
 }
 


### PR DESCRIPTION
Eliminates the forced white background for images and iframes in dark mode, relying solely on mix-blend-mode for visual adjustment.